### PR TITLE
Remove whitespace so the package can be installed.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: person("Ben", "Dilday", email = "ben.dilday.phd@gmail.com",
                   role = c("aut", "cre"))
 Description: Compute Marcel Projections
 License: MIT
-Depends: R(>= 3.1.0) 
+Depends: R(>= 3.1.0)
 Imports:
     dplyr (>= 0.5.0),
     Lahman (>= 5.0-0),


### PR DESCRIPTION
When I tried to install using devtools, I encountered the following error:
'Installation fails with "Invalid comparison operator in dependency: >="'

Some Googling (https://github.com/xnie/rlearner/issues/1) suggested this was a whitespace issue the description file. I think this should hopefully fix the issue.